### PR TITLE
Fix ref leak

### DIFF
--- a/mutable_tuple/mod.c
+++ b/mutable_tuple/mod.c
@@ -20,8 +20,7 @@ tuple_set_item(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "out of bounds");
         return NULL;
     }
-    Py_DECREF(PyTuple_GET_ITEM(tup, index));
-    PyTuple_SET_ITEM(tup, index, obj);
+    PyTuple_SetItem(tup, index, obj);
 
     Py_RETURN_NONE;
 }

--- a/mutable_tuple/mod.c
+++ b/mutable_tuple/mod.c
@@ -20,6 +20,7 @@ tuple_set_item(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "out of bounds");
         return NULL;
     }
+
     PyTuple_SetItem(tup, index, obj);
 
     Py_RETURN_NONE;

--- a/mutable_tuple/mod.c
+++ b/mutable_tuple/mod.c
@@ -21,7 +21,8 @@ tuple_set_item(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    PyTuple_SetItem(tup, index, obj);
+    Py_DECREF(PyTuple_GET_ITEM(tup, index));
+    PyTuple_SET_ITEM(tup, index, obj);
 
     Py_RETURN_NONE;
 }

--- a/mutable_tuple/mod.c
+++ b/mutable_tuple/mod.c
@@ -20,7 +20,7 @@ tuple_set_item(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "out of bounds");
         return NULL;
     }
-    Py_DECREF(PyTUPLE_GET_ITEM(tup, index));
+    Py_DECREF(PyTuple_GET_ITEM(tup, index));
     PyTuple_SET_ITEM(tup, index, obj);
 
     Py_RETURN_NONE;

--- a/mutable_tuple/mod.c
+++ b/mutable_tuple/mod.c
@@ -20,7 +20,7 @@ tuple_set_item(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_IndexError, "out of bounds");
         return NULL;
     }
-
+    Py_DECREF(PyTUPLE_GET_ITEM(tup, index));
     PyTuple_SET_ITEM(tup, index, obj);
 
     Py_RETURN_NONE;


### PR DESCRIPTION
From the [doc entry](https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SET_ITEM) for `PyTuple_SET_ITEM`:
> This function “steals” a reference to o, and, unlike [PyTuple_SetItem()](https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SetItem), does not discard a reference to any item that is being replaced; any reference in the tuple at position pos will be leaked.
